### PR TITLE
Trigger build with khmer latest

### DIFF
--- a/0-install-docker-ci.rst
+++ b/0-install-docker-ci.rst
@@ -35,7 +35,7 @@ Install `khmer <http://khmer.readthedocs.org>`__ from its source code.
     source pondenv/bin/activate
     cd pondenv
     pip install -U setuptools
-    git clone --branch v2.0 https://github.com/dib-lab/khmer.git
+    git clone https://github.com/dib-lab/khmer.git
     cd khmer
     make install
 


### PR DESCRIPTION
Jenkins is no longer available to run acceptance tests. We have stamps running as part of khmer's CI, but we should also do regular eel-pond runs against mater as well. Perhaps on a nightly or weekly basis?

We should set up a Travis cron job for this, and have the literate resting run on both v2.0 and latest. This PR does not do that. Hopefully it triggers a build we can use as an acceptance test.